### PR TITLE
changed the endpoint formats

### DIFF
--- a/backend/careplus/main/models.py
+++ b/backend/careplus/main/models.py
@@ -4,5 +4,5 @@ from django.db import models
 class CustomUser(AbstractUser):
     is_patient = models.BooleanField(default=False)
     is_doctor = models.BooleanField(default=False)
-    registration_id = models.CharField(max_length=50, blank=True, null=True)  # For doctors
-    phone_number = models.CharField(max_length=15, blank=True, null=True)    # For doctors
+    registration_id = models.CharField(max_length=50, blank=True, null=True, unique=True)  # Unique for doctors
+    phone_number = models.CharField(max_length=15, blank=True, null=True)  # For doctors

--- a/backend/careplus/main/serializers.py
+++ b/backend/careplus/main/serializers.py
@@ -1,3 +1,4 @@
+### serializers.py
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 
@@ -5,18 +6,24 @@ User = get_user_model()
 
 class RegisterSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True)
+    email = serializers.EmailField(allow_null=True, required=False)  # Allow null email for doctors
 
     class Meta:
         model = User
         fields = ['username', 'email', 'password', 'is_patient', 'is_doctor', 'registration_id', 'phone_number']
 
     def create(self, validated_data):
+        if User.objects.filter(username=validated_data['username']).exists():
+            raise serializers.ValidationError({"error": "A user with that username already exists."})
+        if validated_data.get('email') and User.objects.filter(email=validated_data['email']).exists():
+            raise serializers.ValidationError({"error": "A user with that email already exists."})
+        
         user = User.objects.create_user(
             username=validated_data['username'],
-            email=validated_data['email'],
+            email=validated_data.get('email', None),
             password=validated_data['password'],
             is_patient=validated_data.get('is_patient', False),
-            is_doctor=validated_data.get('is_doctor', False),
+            is_doctor=validated_data.get('is_doctor', False),   
             registration_id=validated_data.get('registration_id', None),
             phone_number=validated_data.get('phone_number', None),
         )

--- a/backend/careplus/main/urls.py
+++ b/backend/careplus/main/urls.py
@@ -1,13 +1,12 @@
 from django.urls import path
-from .views import RegisterView, LoginView
+from .views import RegisterView, LoginView, TokenRefreshView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
-    TokenRefreshView,
 )
 
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('login/', LoginView.as_view(), name='login'),
-     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/backend/careplus/main/views.py
+++ b/backend/careplus/main/views.py
@@ -1,13 +1,13 @@
+### views.py
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from django.contrib.auth import authenticate
 from .serializers import RegisterSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
-from django.contrib.auth import authenticate
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
 
 class RegisterView(APIView):
     def post(self, request):
@@ -15,19 +15,36 @@ class RegisterView(APIView):
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
+        
+        # Check if user already exists
+        if 'email' in serializer.errors or 'username' in serializer.errors:
+            return Response(serializer.errors, status=status.HTTP_409_CONFLICT)
+        
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class LoginView(APIView):
     def post(self, request):
-        username = request.data.get('username')
+        email = request.data.get('email')
+        registration_id = request.data.get('registration_id')
         password = request.data.get('password')
-        user = authenticate(username=username, password=password)
 
-        if user:
-            # Generate JWT tokens
+        user = None
+        if email:
+            try:
+                user = User.objects.get(email=email)
+            except User.DoesNotExist:
+                return Response({'error': 'Invalid credentials'}, status=status.HTTP_400_BAD_REQUEST)
+
+        elif registration_id:
+            try:
+                user = User.objects.get(registration_id=registration_id)
+            except User.DoesNotExist:
+                return Response({'error': 'Invalid credentials'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if user and user.check_password(password):
             refresh = RefreshToken.for_user(user)
             return Response({
-                'username': user.username,
+                'uid': user.id,
                 'email': user.email,
                 'is_patient': user.is_patient,
                 'is_doctor': user.is_doctor,
@@ -37,4 +54,19 @@ class LoginView(APIView):
                 'access': str(refresh.access_token),
                 'message': 'Login successful!'
             }, status=status.HTTP_200_OK)
+
         return Response({'error': 'Invalid credentials'}, status=status.HTTP_400_BAD_REQUEST)
+
+class TokenRefreshView(APIView):
+    def post(self, request):
+        refresh_token = request.data.get("refresh")
+        if not refresh_token:
+            return Response({"error": "Refresh token is required"}, status=status.HTTP_400_BAD_REQUEST)
+        
+        try:
+            refresh = RefreshToken(refresh_token)
+            return Response({
+                "access": str(refresh.access_token)
+            }, status=status.HTTP_200_OK)
+        except Exception as e:
+            return Response({"error": "Invalid refresh token"}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
1. Change the response status code of register API to 409 if the user already exist. At present it is 400 which is a common bad request status code.
2. The email field will be null when a doctor tries to register with doctors registration_Id. At present server do not accept request with email field as null
3. Replace the username key in the request body of the login api with email and registration_id fields as patient login using email and doctor tries to login using registration_Id. At present username is not used for login/register purposes